### PR TITLE
Add ArangoDB snapshot store

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,3 @@
+# for php-coveralls
+service_name: travis-ci
+coverage_clover: build/logs/clover.xml

--- a/.docheader
+++ b/.docheader
@@ -1,0 +1,8 @@
+/**
+ * This file is part of the prooph/arangodb-snapshot-store.
+ * (c) 2016-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2016-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/docs             export-ignore
+/examples         export-ignore
+/tests            export-ignore
+.coveralls.yml    export-ignore
+.docheader        export-ignore
+.gitignore        export-ignore
+.php_cs           export-ignore
+.travis.yml       export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/.settings
+/.project
+/.buildpath
+/vendor
+/build
+.idea
+phpunit.xml
+.php_cs.cache
+nbproject
+composer.lock
+docs/html

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,10 @@
+<?php
+
+$config = new Prooph\CS\Config\Prooph();
+$config->getFinder()->in(__DIR__);
+
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+
+$config->setCacheFile($cacheDir . '/.php_cs.cache');
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,63 @@
+language: php
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.1
+      env:
+        - DEPENDENCIES=""
+        - EXECUTE_CS_CHECK=true
+        - TEST_COVERAGE=true
+        - ARANGODB_VERSION=3.0
+    - php: 7.1
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+        - ARANGODB_VERSION=3.0
+    - php: 7.1
+      env:
+        - DEPENDENCIES=""
+        - EXECUTE_CS_CHECK=true
+        - TEST_COVERAGE=true
+        - ARANGODB_VERSION=3.1
+    - php: 7.1
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+        - ARANGODB_VERSION=3.1
+
+addons:
+  hosts:
+    - arangodb
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.php-cs-fixer
+    - $HOME/.local
+
+before_script:
+  - mkdir -p "$HOME/.php-cs-fixer"
+  - phpenv config-rm xdebug.ini
+  - composer self-update
+  - composer update --prefer-dist $DEPENDENCIES
+  - wget https://www.arangodb.com/repositories/travisCI/setup_arangodb_${ARANGODB_VERSION}.sh
+  - chmod 777 setup_arangodb_${ARANGODB_VERSION}.sh
+  - ./setup_arangodb_${ARANGODB_VERSION}.sh
+
+script:
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; fi
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/docheader check src/ tests/; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi
+
+after_success:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/coveralls -v; fi
+
+after_script:
+  - killall -s SIGTERM arangod_x86_64
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/61c75218816eebde4486
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2016-2016, prooph software GmbH
+Copyright (c) 2016-2016, Sascha-Oliver Prolic
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the prooph software GmbH nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
-# arangodb-snapshot-store
+# Prooph ArangoDB Snapshot Store
 
 [![Build Status](https://travis-ci.org/prooph/arangodb-snapshot-store.svg?branch=master)](https://travis-ci.org/prooph/arangodb-snapshot-store)
 [![Coverage Status](https://coveralls.io/repos/github/prooph/arangodb-snapshot-store/badge.svg?branch=master)](https://coveralls.io/github/prooph/arangodb-snapshot-store?branch=master)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prooph/improoph)
 
-ArangoDb Snapshot Store implementation
+## Overview
+
+[ArangoDB](https://www.arangodb.com/) implementation of snapshot store
+
+## Installation
+
+You can install prooph/arangodb-snapshot-store via composer by adding `"prooph/arangodb-snapshot-store": "^1.0"` as requirement to your composer.json.
+
+## Requirements
+
+- PHP 7.1
+- ArangoDB >= 3.0
+
+## Support
+
+- Ask questions on [prooph-users](https://groups.google.com/forum/?hl=de#!forum/prooph) mailing list.
+- File issues at [https://github.com/prooph/arangodb-snapshot-store/issues](https://github.com/prooph/arangodb-snapshot-store/issues).
+- Say hello in the [prooph gitter](https://gitter.im/prooph/improoph) chat.
+
+## Contribute
+
+Please feel free to fork and extend existing or add new plugins and send a pull request with your changes!
+To establish a consistent code quality, please provide unit tests for all your changes and may adapt the documentation.
+
+## License
+
+Released under the [New BSD License](LICENSE).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  php:
+    image: prooph/php:7.1-cli-xdebug
+    volumes:
+      - "./:/app"
+
+  arangodb:
+    image: arangodb:3.1.4
+    ports:
+      - 8529:8529
+    environment:
+      - ARANGO_NO_AUTH=1

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuite name="prooph ArangoDB Snapshot Store Test Suite">
+        <directory>./tests/</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+
+    <php>
+        <var name="arangodb_host" value="tcp://arangodb:8529" />
+        <var name="arangodb_username" value="" />
+        <var name="arangodb_password" value="" />
+        <var name="arangodb_dbname" value="_system" />
+    </php>
+</phpunit>

--- a/src/ArangoDBSnapshotStore.php
+++ b/src/ArangoDBSnapshotStore.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * This file is part of the prooph/arangodb-snapshot-store.
+ * (c) 2016-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\ArangoDB\SnapshotStore;
+
+use ArangoDBClient\Batch;
+use ArangoDBClient\Connection;
+use ArangoDBClient\Statement;
+use Prooph\EventSourcing\Aggregate\AggregateType;
+use Prooph\EventSourcing\Snapshot\Snapshot;
+use Prooph\EventSourcing\Snapshot\SnapshotStore;
+
+final class ArangoDBSnapshotStore implements SnapshotStore
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * Custom sourceType to snapshot mapping
+     *
+     * @var array
+     */
+    private $snapshotCollectionMap;
+
+    /**
+     * @var string
+     */
+    private $defaultSnapshotCollectionName;
+
+    public function __construct(
+        Connection $connection,
+        array $snapshotCollectionMap = [],
+        string $defaultSnapshotCollectionName = 'snapshots'
+    ) {
+        $this->connection = $connection;
+        $this->snapshotCollectionMap = $snapshotCollectionMap;
+        $this->defaultSnapshotCollectionName = $defaultSnapshotCollectionName;
+    }
+
+    public function get(AggregateType $aggregateType, string $aggregateId): ?Snapshot
+    {
+        $collectionName = $this->getCollectionName($aggregateType);
+
+        $statement = new Statement(
+            $this->connection, [
+                'query' => 'FOR s IN @@collection FILTER s._key == @aggregate_id SORT s.last_version DESC RETURN s',
+                'bindVars' => [
+                    '@collection' => $collectionName,
+                    'aggregate_id' => $aggregateId,
+                ],
+            ]
+        );
+
+        $cursor = $statement->execute();
+
+        if (! $cursor->getCount()) {
+            return null;
+        }
+
+        $result = $cursor->current();
+
+        return new Snapshot(
+            $aggregateType,
+            $aggregateId,
+            unserialize($result->aggregate_root),
+            (int) $result->last_version,
+            \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', $result->created_at, new \DateTimeZone('UTC'))
+        );
+    }
+
+    public function save(Snapshot $snapshot): void
+    {
+        $collectionName = $this->getCollectionName($snapshot->aggregateType());
+
+        $batch = new Batch($this->connection);
+
+        $batch->append(
+            'DELETE',
+            'DELETE /_api/document/' . $collectionName . '/' . $snapshot->aggregateId() . ' HTTP/1.1'
+        );
+
+        $data = [
+            '_key' => $snapshot->aggregateId(),
+            'aggregate_type' => $snapshot->aggregateType()->toString(),
+            'last_version' => $snapshot->lastVersion(),
+            'created_at' => $snapshot->createdAt()->format('Y-m-d\TH:i:s.u'),
+            'aggregate_root' => serialize($snapshot->aggregateRoot()),
+        ];
+
+        $batch->append(
+            'POST',
+            'POST /_api/document/' . $collectionName . "?silent=true HTTP/1.1\n\n"
+            . $this->connection->json_encode_wrapper($data)
+        );
+
+        $batch->process();
+    }
+
+    private function getCollectionName(AggregateType $aggregateType): string
+    {
+        $collectionName = $this->defaultSnapshotCollectionName;
+
+        if (isset($this->snapshotCollectionMap[$aggregateType->toString()])) {
+            $collectionName = $this->snapshotCollectionMap[$aggregateType->toString()];
+        }
+
+        return $collectionName;
+    }
+}

--- a/src/Container/ArangoDBSnapshotStoreFactory.php
+++ b/src/Container/ArangoDBSnapshotStoreFactory.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * This file is part of the prooph/arangodb-snapshot-store.
+ * (c) 2016-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\ArangoDB\SnapshotStore\Container;
+
+use ArangoDBClient\Connection;
+use ArangoDBClient\ConnectionOptions;
+use ArangoDBClient\UpdatePolicy;
+use Interop\Config\ConfigurationTrait;
+use Interop\Config\ProvidesDefaultOptions;
+use Interop\Config\RequiresConfigId;
+use Interop\Container\ContainerInterface;
+use Prooph\ArangoDB\SnapshotStore\ArangoDBSnapshotStore;
+
+class ArangoDBSnapshotStoreFactory implements ProvidesDefaultOptions, RequiresConfigId
+{
+    use ConfigurationTrait;
+
+    /**
+     * @var string
+     */
+    private $configId;
+
+    /**
+     * Creates a new instance from a specified config, specifically meant to be used as static factory.
+     *
+     * In case you want to use another config key than provided by the factories, you can add the following factory to
+     * your config:
+     *
+     * <code>
+     * <?php
+     * return [
+     *     ArangoDBSnapshotStore::class => [ArangoDBSnapshotStoreFactory::class, 'service_name'],
+     * ];
+     * </code>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function __callStatic(string $name, array $arguments): ArangoDBSnapshotStore
+    {
+        if (! isset($arguments[0]) || ! $arguments[0] instanceof ContainerInterface) {
+            throw new \InvalidArgumentException(
+                sprintf('The first argument must be of type %s', ContainerInterface::class)
+            );
+        }
+
+        return (new static($name))->__invoke($arguments[0]);
+    }
+
+    public function __invoke(ContainerInterface $container): ArangoDBSnapshotStore
+    {
+        $config = $container->get('config');
+        $config = $this->options($config, $this->configId);
+
+        if (isset($config['arangodb_client_service'])) {
+            $connection = $container->get($config['arangodb_client_service']);
+        } else {
+            $connection = new Connection($config['connection_options']);
+        }
+
+        return new ArangoDBSnapshotStore(
+            $connection,
+            $config['snapshot_collection_map'],
+            $config['default_snapshot_collection_name']
+        );
+    }
+
+    public function __construct(string $configId = 'default')
+    {
+        $this->configId = $configId;
+    }
+
+    public function dimensions(): iterable
+    {
+        return ['prooph', 'arangodb_snapshot_store'];
+    }
+
+    public function defaultOptions(): iterable
+    {
+        return [
+            'connection_options' => [
+                ConnectionOptions::OPTION_DATABASE => 'snapshot_store',
+                ConnectionOptions::OPTION_ENDPOINT => 'tcp://arangodb:8529',
+                ConnectionOptions::OPTION_AUTH_TYPE => 'Basic',
+                ConnectionOptions::OPTION_AUTH_USER => '',
+                ConnectionOptions::OPTION_AUTH_PASSWD => '',
+                ConnectionOptions::OPTION_CONNECTION => 'Close',
+                ConnectionOptions::OPTION_TIMEOUT => 3,
+                ConnectionOptions::OPTION_RECONNECT => true,
+                ConnectionOptions::OPTION_CREATE => true,
+                ConnectionOptions::OPTION_UPDATE_POLICY => UpdatePolicy::LAST,
+            ],
+            'snapshot_collection_map' => [],
+            'default_snapshot_collection_name' => 'snapshots',
+        ];
+    }
+}

--- a/tests/ArangoDBSnapshotStoreTest.php
+++ b/tests/ArangoDBSnapshotStoreTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of the prooph/arangodb-snapshot-store.
+ * (c) 2016-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\ArangoDB\SnapshotStore;
+
+use ArangoDBClient\Connection;
+use ArangoDBClient\Urls;
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+use Prooph\ArangoDB\SnapshotStore\ArangoDBSnapshotStore;
+use Prooph\EventSourcing\Aggregate\AggregateType;
+use Prooph\EventSourcing\Snapshot\Snapshot;
+use ProophTest\EventSourcing\Mock\User;
+
+class ArangoDBSnapshotStoreTest extends TestCase
+{
+    /**
+     * @var ArangoDBSnapshotStore
+     */
+    private $snapshotStore;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @test
+     */
+    public function it_saves_and_reads()
+    {
+        $aggregateRoot = User::nameNew('Sandro');
+        $aggregateType = AggregateType::fromAggregateRoot($aggregateRoot);
+
+        $date = date('Y-m-d\TH:i:s.u');
+        $now = DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', $date, new DateTimeZone('UTC'));
+
+        $snapshot = new Snapshot($aggregateType, 'id', $aggregateRoot, 1, $now);
+        $this->snapshotStore->save($snapshot);
+
+        $snapshot = new Snapshot($aggregateType, 'id', $aggregateRoot, 2, $now);
+        $this->snapshotStore->save($snapshot);
+
+        $this->assertNull($this->snapshotStore->get($aggregateType, 'invalid'));
+
+        $readSnapshot = $this->snapshotStore->get($aggregateType, 'id');
+        $this->assertEquals($snapshot, $readSnapshot);
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_snapshot_table_map()
+    {
+        $aggregateType = AggregateType::fromAggregateRootClass(\stdClass::class);
+        $aggregateRoot = new \stdClass();
+        $aggregateRoot->foo = 'bar';
+
+        $date = date('Y-m-d\TH:i:s.u');
+        $now = DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.u', $date, new DateTimeZone('UTC'));
+
+        $snapshot = new Snapshot($aggregateType, 'id', $aggregateRoot, 1, $now);
+
+        $this->snapshotStore->save($snapshot);
+
+        $response = $this->connection->get(Urls::URL_COLLECTION . '/bar/count')->getJson();
+        $this->assertSame(1, $response['count'] ?? 0);
+
+        $readSnapshot = $this->snapshotStore->get($aggregateType, 'id');
+        $this->assertEquals($snapshot, $readSnapshot);
+    }
+
+    protected function setUp(): void
+    {
+        $this->connection = TestUtil::getClient();
+
+        $this->connection->post(Urls::URL_COLLECTION, $this->connection->json_encode_wrapper(['name' => 'snapshots']));
+        $this->connection->post(Urls::URL_COLLECTION, $this->connection->json_encode_wrapper(['name' => 'bar']));
+
+        $this->snapshotStore = new ArangoDBSnapshotStore(
+            $this->connection,
+            [\stdClass::class => 'bar'],
+            'snapshots'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection->delete(Urls::URL_COLLECTION . '/snapshots');
+        $this->connection->delete(Urls::URL_COLLECTION . '/bar');
+        unset($this->connection);
+    }
+}

--- a/tests/Container/ArangoDBSnapshotStoreFactoryTest.php
+++ b/tests/Container/ArangoDBSnapshotStoreFactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This file is part of the prooph/arangodb-snapshot-store.
+ * (c) 2016-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\ArangoDB\SnapshotStore\Container;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit\Framework\TestCase;
+use Prooph\ArangoDB\SnapshotStore\ArangoDBSnapshotStore;
+use Prooph\ArangoDB\SnapshotStore\Container\ArangoDBSnapshotStoreFactory;
+use ProophTest\ArangoDB\SnapshotStore\TestUtil;
+
+class ArangoDBSnapshotStoreFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_adapter_via_connection_service(): void
+    {
+        $config['prooph']['arangodb_snapshot_store']['default'] = [
+            'arangodb_client_service' => 'my_connection',
+        ];
+
+        $client = TestUtil::getClient();
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->get('my_connection')->willReturn($client)->shouldBeCalled();
+        $container->get('config')->willReturn($config)->shouldBeCalled();
+
+        $factory = new ArangoDBSnapshotStoreFactory();
+        $snapshotStore = $factory($container->reveal());
+
+        $this->assertInstanceOf(ArangoDBSnapshotStore::class, $snapshotStore);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_adapter_via_connection_options(): void
+    {
+        $config['prooph']['arangodb_snapshot_store']['custom'] = [
+            'connection_options' => TestUtil::getConnectionParams(),
+        ];
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->get('config')->willReturn($config)->shouldBeCalled();
+
+        $snapshotStoreName = 'custom';
+        $snapshotStore = ArangoDBSnapshotStoreFactory::$snapshotStoreName($container->reveal());
+
+        $this->assertInstanceOf(ArangoDBSnapshotStore::class, $snapshotStore);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_invalid_container_given(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $eventStoreName = 'custom';
+        ArangoDBSnapshotStoreFactory::$eventStoreName('invalid container');
+    }
+}

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of the prooph/arangodb-snapshot-store.
+ * (c) 2016-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\ArangoDB\SnapshotStore;
+
+use ArangoDBClient\Connection;
+use ArangoDBClient\ConnectionOptions;
+use ArangoDBClient\UpdatePolicy;
+
+abstract class TestUtil
+{
+    public static function getClient(): Connection
+    {
+        return new Connection(self::getConnectionParams());
+    }
+
+    public static function getDatabaseName(): string
+    {
+        if (! self::hasRequiredConnectionParams()) {
+            throw new \RuntimeException('No connection params given');
+        }
+
+        return $GLOBALS['arangodb_dbname'];
+    }
+
+    public static function getConnectionParams(): array
+    {
+        if (! self::hasRequiredConnectionParams()) {
+            throw new \RuntimeException('No connection params given');
+        }
+
+        return self::getSpecifiedConnectionParams();
+    }
+
+    private static function hasRequiredConnectionParams(): bool
+    {
+        return isset(
+            $GLOBALS['arangodb_username'],
+            $GLOBALS['arangodb_password'],
+            $GLOBALS['arangodb_host'],
+            $GLOBALS['arangodb_dbname']
+        );
+    }
+
+    private static function getSpecifiedConnectionParams(): array
+    {
+        return [
+            ConnectionOptions::OPTION_AUTH_TYPE => 'Basic',
+            ConnectionOptions::OPTION_CONNECTION => 'Close',
+            ConnectionOptions::OPTION_TIMEOUT => 3,
+            ConnectionOptions::OPTION_RECONNECT => false,
+            ConnectionOptions::OPTION_CREATE => false,
+            ConnectionOptions::OPTION_UPDATE_POLICY => UpdatePolicy::LAST,
+            ConnectionOptions::OPTION_AUTH_USER => $GLOBALS['arangodb_username'],
+            ConnectionOptions::OPTION_AUTH_PASSWD => $GLOBALS['arangodb_password'],
+            ConnectionOptions::OPTION_ENDPOINT => $GLOBALS['arangodb_host'],
+            ConnectionOptions::OPTION_DATABASE => $GLOBALS['arangodb_dbname'],
+        ];
+    }
+}


### PR DESCRIPTION
@codeliner Can you enable TravisCI and the other tools for this package, please?

Here is an example for `docker-compose.yml`

```yml
version: '2'
services:
  php:
    image: prooph/php:7.1-cli-xdebug
    volumes:
      - "./:/app"

  arangodb:
    image: arangodb:3.1.4
    ports:
      - 8529:8529
    environment:
      - ARANGO_NO_AUTH=1
```

Then change `arangodb_host` in `phpunit.xml.dist` to `tcp://arangodb:8529` and run:

```
$ docker-compose up -d --no-recreate
$ docker-compose run --rm -e PHP_IDE_CONFIG="serverName=application" php php -d xdebug.remote_autostart=1 -d xdebug.remote_host=172.17.0.1 vendor/bin/phpunit
```